### PR TITLE
folder ash: our coxeter problem solution

### DIFF
--- a/coxeter_group_orbits/ash/Makefile
+++ b/coxeter_group_orbits/ash/Makefile
@@ -1,0 +1,35 @@
+SHELL = /bin/sh
+
+.SUFFIXES:
+.SUFFIXES: .cc .o
+
+BOOSTDIR = /usr/lib# was: /home/julian/software/boost_1_57_0
+
+INCLUDEDIR = -I. -I$(BOOSTDIR)
+LIBDIR = -L$(BOOSTDIR)/lib
+LIBS = -lboost_unit_test_framework
+CFLAGS = -Wall -Wextra -Wpedantic -std=c++1y -O3 -g
+CC = g++
+
+test_orbits: test_orbits.o
+	$(CC) $(LIBDIR) $(CFLAGS) $< $(LIBS) -o $@
+
+test_orbits.o: test_orbits.cc orbit.h
+	$(CC) $(INCLUDEDIR) $(CFLAGS) -c $< -o $@
+
+
+main: main.o
+	$(CC) $(CFLAGS) $< -o $@
+
+main.o: main.cc orbit.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+
+main2: main2.o
+	$(CC) $(CFLAGS) $< -o $@
+
+main2.o: main2.cc orbit.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f *.o test_orbits main main2

--- a/coxeter_group_orbits/ash/NewCoxeterCalculationTimes.txt
+++ b/coxeter_group_orbits/ash/NewCoxeterCalculationTimes.txt
@@ -1,0 +1,11 @@
+Coxeter Group B3: 0 sec - size: 48
+Coxeter Group B4: 0 sec - size: 384
+Coxeter Group B5: 1 sec - size: 3840
+Coxeter Group B6: 28 sec - size: 46080
+Coxeter Group D3: 0 sec - size: 24
+Coxeter Group D4: 0 sec - size: 192
+Coxeter Group D5: 0 sec - size: 1920
+Coxeter Group E6: 14 sec - size: 51840
+Coxeter Group F4: 0 sec - size: 1152
+Coxeter Group H3: 0 sec - size: 120
+Coxeter Group H4: 0 sec - size: 14400

--- a/coxeter_group_orbits/ash/main.cc
+++ b/coxeter_group_orbits/ash/main.cc
@@ -5,22 +5,24 @@
 #include "test_orbitSize.h"
 
 
-int main(int arg, const char* argv[]){
+//int main(int arg, const char* argv[]){
+int main(){
 	time_t start;
 	time_t end;
 
 	std::ofstream f ("NewCoxeterCalculationTimes.txt");
-	 
+	VectorType v;
+	Orbit o;
 ////////////////////////////////////////////////////////////
 //Coxeter Group B
 	//B3
 	GeneratorList g = simple_roots('B', 3);
-	VectorType v = getVectorGeneralPosition('B',3);
+	v = getVectorGeneralPosition('B',3);
 	time(&start);
-	Orbit o = orbit(g,v);
+	o = orbit(g,v);
 	time(&end);
 	f << "Coxeter Group B3: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
-/*	//B4
+	//B4
 	g = simple_roots('B', 4);
 	v = getVectorGeneralPosition('B',4);
 	time(&start);
@@ -41,6 +43,7 @@ int main(int arg, const char* argv[]){
 	o = orbit(g,v);
 	time(&end);
 	f << "Coxeter Group B6: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
+	/*
 	//B7
 	g = simple_roots('B', 7);
 	v = getVectorGeneralPosition('B',7);
@@ -55,6 +58,7 @@ int main(int arg, const char* argv[]){
 	o = orbit(g,v);
 	time(&end);
 	f << "Coxeter Group B8: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
+	*/
 /////////////////////////////////////////////////////////////////////
 //Coxeter Group D
         //D3
@@ -78,13 +82,14 @@ int main(int arg, const char* argv[]){
 	o = orbit(g,v);
 	time(&end);
 	f << "Coxeter Group D5: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
-	//D6
+	/*/D6
 	g = simple_roots('D', 6);
 	v = getVectorGeneralPosition('D',6);
 	time(&start);
 	o = orbit(g,v);
 	time(&end);
-	f << "Coxeter Group D6: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";*/
+	f << "Coxeter Group D6: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
+	*/
 ////////////////////////////////////////////////////////////
 //Coxeter Group E 
 	//E6
@@ -95,7 +100,7 @@ int main(int arg, const char* argv[]){
 	o = orbit(g,{1.0,2.0,3.0,4.0,5.0,6.0});
 	time(&end);
 	f << "Coxeter Group E6: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
-	/*//E7
+	/*/E7
 	g = simple_roots('E', 7);
 	v = getVectorGeneralPosition('E',7);
 	time(&start);
@@ -109,6 +114,7 @@ int main(int arg, const char* argv[]){
 	o = orbit(g, {1,2,3,4,5,6,7,8});
 	time(&end);
 	f << "Coxeter Group E8: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
+	*/
 ////////////////////////////////////////////////////////////
 //Coxeter Group F
 	//F4
@@ -121,23 +127,22 @@ int main(int arg, const char* argv[]){
 //////////////////////////////////////////////////////////
 //Coxeter Group H
 	//H3
-	GeneratorList g = simple_roots('H', 3);
-        VectorType v = getVectorGeneralPosition('H',3);
+	g = simple_roots('H', 3);
+    v = getVectorGeneralPosition('H',3);
 	time(&start);
-	Orbit o = orbit(g, v);
-	std::cout << "polymake 'new Polytope(POINTS=>";
-
-	output_set(o);
-	std::cout << ")->VISUAL;'\n" << o.size() << std::endl;
+	o = orbit(g, v);
+	//std::cout << "polymake 'new Polytope(POINTS=>";
+	//output_set(o);
+	//std::cout << ")->VISUAL;'\n" << o.size() << std::endl;
 	time(&end);
 	f << "Coxeter Group H3: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
 	//H4
 	g = simple_roots('H', 4);
-        v = getVectorGeneralPosition('H',4);
+    v = getVectorGeneralPosition('H',4);
 	time(&start);
 	o = orbit(g, v);
 	time(&end);
-	f << "Coxeter Group H4: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";*/
+	f << "Coxeter Group H4: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
 /////////////////////////////////////////////////////////
 	f.close();
 }

--- a/coxeter_group_orbits/ash/main.cc
+++ b/coxeter_group_orbits/ash/main.cc
@@ -9,8 +9,8 @@ int main(int arg, const char* argv[]){
 	time_t start;
 	time_t end;
 
-	std::ofstream f ("CoexeterCalculationTimes.txt");
-	/* 
+	std::ofstream f ("NewCoxeterCalculationTimes.txt");
+	 
 ////////////////////////////////////////////////////////////
 //Coxeter Group B
 	//B3
@@ -20,7 +20,7 @@ int main(int arg, const char* argv[]){
 	Orbit o = orbit(g,v);
 	time(&end);
 	f << "Coxeter Group B3: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
-	//B4
+/*	//B4
 	g = simple_roots('B', 4);
 	v = getVectorGeneralPosition('B',4);
 	time(&start);
@@ -57,7 +57,7 @@ int main(int arg, const char* argv[]){
 	f << "Coxeter Group B8: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
 /////////////////////////////////////////////////////////////////////
 //Coxeter Group D
-	//D3
+        //D3
 	g = simple_roots('D', 3);
 	v = getVectorGeneralPosition('D',3);
 	time(&start);
@@ -84,7 +84,7 @@ int main(int arg, const char* argv[]){
 	time(&start);
 	o = orbit(g,v);
 	time(&end);
-	f << "Coxeter Group D6: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
+	f << "Coxeter Group D6: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";*/
 ////////////////////////////////////////////////////////////
 //Coxeter Group E 
 	//E6
@@ -95,7 +95,7 @@ int main(int arg, const char* argv[]){
 	o = orbit(g,{1.0,2.0,3.0,4.0,5.0,6.0});
 	time(&end);
 	f << "Coxeter Group E6: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
-	//E7
+	/*//E7
 	g = simple_roots('E', 7);
 	v = getVectorGeneralPosition('E',7);
 	time(&start);
@@ -103,12 +103,12 @@ int main(int arg, const char* argv[]){
 	o = orbit(g,{1.0,2.0,3.0,4.0,5.0,6.0,7.0});
 	time(&end);
 	f << "Coxeter Group E7: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
-	/*E8
+	//E8
 	g = simple_roots('E', 8);
 	time(&start);
 	o = orbit(g, {1,2,3,4,5,6,7,8});
 	time(&end);
-	f1 << "Coxeter Group E8: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
+	f << "Coxeter Group E8: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
 ////////////////////////////////////////////////////////////
 //Coxeter Group F
 	//F4
@@ -121,7 +121,6 @@ int main(int arg, const char* argv[]){
 //////////////////////////////////////////////////////////
 //Coxeter Group H
 	//H3
-*/
 	GeneratorList g = simple_roots('H', 3);
         VectorType v = getVectorGeneralPosition('H',3);
 	time(&start);
@@ -138,7 +137,7 @@ int main(int arg, const char* argv[]){
 	time(&start);
 	o = orbit(g, v);
 	time(&end);
-	f << "Coxeter Group H4: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";
+	f << "Coxeter Group H4: " << difftime(end, start) << " sec - size: " << o.size() <<"\n";*/
 /////////////////////////////////////////////////////////
 	f.close();
 }

--- a/coxeter_group_orbits/ash/test_orbitSize.h
+++ b/coxeter_group_orbits/ash/test_orbitSize.h
@@ -77,8 +77,8 @@
    bool swap(VectorType& a, VectorType& b){
       VectorType x(a);
       for (VectorType::size_type i = 0; i != a.size(); i++){
-            a[i] == b[i];
-            b[i] == x[i];
+            a[i] = b[i];
+            b[i] = x[i];
          }
       return true;
    }

--- a/coxeter_group_orbits/ash/test_orbits.cc
+++ b/coxeter_group_orbits/ash/test_orbits.cc
@@ -48,27 +48,90 @@ BOOST_AUTO_TEST_CASE( generators )
                      );
 }
 
+//////// B ////////
 struct b3_fixture {
   b3_fixture() 
     : generators(simple_roots('B', 3)) 
   {}
   GeneratorList generators;
 };
+struct b4_fixture {
+  b4_fixture() 
+    : generators(simple_roots('B', 4)) 
+  {}
+  GeneratorList generators;
+};
+struct b5_fixture {
+  b5_fixture() 
+    : generators(simple_roots('B', 5)) 
+  {}
+  GeneratorList generators;
+};
+struct b6_fixture {
+  b6_fixture() 
+    : generators(simple_roots('B', 6)) 
+  {}
+  GeneratorList generators;
+};
+struct b7_fixture {
+  b7_fixture() 
+    : generators(simple_roots('B', 7)) 
+  {}
+  GeneratorList generators;
+};
+struct b8_fixture {
+  b8_fixture() 
+    : generators(simple_roots('B', 8)) 
+  {}
+  GeneratorList generators;
+};
 
+//////// D ////////
+struct d5_fixture {
+  d5_fixture() 
+    : generators(simple_roots('D', 5)) 
+  {}
+  GeneratorList generators;
+};
+
+//////// E ////////
 struct e6_fixture {
   e6_fixture() 
     : generators(simple_roots('E', 6)) 
   {}
   GeneratorList generators;
 };
+struct e7_fixture {
+  e7_fixture() 
+    : generators(simple_roots('E', 7)) 
+  {}
+  GeneratorList generators;
+};
 
+//////// F ////////
+struct f4_fixture {
+  f4_fixture() 
+    : generators(simple_roots('F', 4)) 
+  {}
+  GeneratorList generators;
+};
+
+//////// H ////////
 struct h3_fixture {
   h3_fixture() 
     : generators(simple_roots('H', 3)) 
   {}
   GeneratorList generators;
 };
+struct h4_fixture {
+  h4_fixture() 
+    : generators(simple_roots('H', 4)) 
+  {}
+  GeneratorList generators;
+};
 
+
+//////// B ////////
 BOOST_FIXTURE_TEST_CASE( b3_orbit_012, b3_fixture )
 {
   BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3}).size(), (size_t) 48);
@@ -88,31 +151,69 @@ BOOST_FIXTURE_TEST_CASE( b3_orbit_01, b3_fixture )
 {
   BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 0}).size(), (size_t) 24);
 }
-
 BOOST_FIXTURE_TEST_CASE( b3_orbit_0, b3_fixture )
 {
   BOOST_CHECK_EQUAL(orbit(generators, {1, 0, 0}).size(), (size_t) 6);
 }
-/*
 BOOST_FIXTURE_TEST_CASE( b3_orbit_1, b3_fixture )
 {
   BOOST_CHECK_EQUAL(orbit(generators, {1, 1, 0}).size(), (size_t) 12);
 }
-
 BOOST_FIXTURE_TEST_CASE( b3_orbit_2, b3_fixture )
 {
   BOOST_CHECK_EQUAL(orbit(generators, {1, 1, 1}).size(), (size_t) 8);
 }
-//E6
-BOOST_FIXTURE_TEST_CASE( e6_orbit, e6_fixture )
+
+BOOST_FIXTURE_TEST_CASE( b5_orbit, b5_fixture )
 {
-  BOOST_CHECK_EQUAL(orbit(generators, {1, 1, 1, 1, 1, 1}).size(), (size_t) 8);
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3, 4, 5}).size(), (size_t) 3840);
+}
+
+BOOST_FIXTURE_TEST_CASE( b6_orbit, b6_fixture )
+{
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3, 4, 5, 6}).size(), (size_t) 46080);
+}
+
+/*
+BOOST_FIXTURE_TEST_CASE( b7_orbit, b7_fixture )
+{
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3, 4, 5, 6, 7}).size(), (size_t) 645120);
+}
+BOOST_FIXTURE_TEST_CASE( b8_orbit, b8_fixture )
+{
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 0, 0, 0, 0, 0, 0, 0}).size(), (size_t) 10321920);
 }
 */
-//H3
+//////// D ////////
+BOOST_FIXTURE_TEST_CASE( d5_orbit, d5_fixture )
+{
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3, 4, 5}).size(), (size_t) 1920);
+}
+
+//////// E ////////
+BOOST_FIXTURE_TEST_CASE( e6_orbit, e6_fixture )
+{
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3, 4, 5, 6}).size(), (size_t) 51840);
+}
+/*BOOST_FIXTURE_TEST_CASE( e7_orbit, e7_fixture )
+{
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 0, 0, 0, 0, 0, 0}).size(), (size_t) 2903040);
+}
+*/
+//////// F ////////
+BOOST_FIXTURE_TEST_CASE( f4_orbit, f4_fixture )
+{
+  BOOST_CHECK_EQUAL(orbit(generators, {3, 2, 1, -5}).size(), (size_t) 1152);
+}
+
+//////// H ////////
 BOOST_FIXTURE_TEST_CASE( h3_orbit, h3_fixture )
 {
-  BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3}).size(), (size_t) 8);
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3}).size(), (size_t) 120);
+}
+BOOST_FIXTURE_TEST_CASE( h4_orbit, h4_fixture )
+{
+  BOOST_CHECK_EQUAL(orbit(generators, {1, 2, 3, 4}).size(), (size_t) 14400);
 }
 
 

--- a/coxeter_group_orbits/ash/types.h
+++ b/coxeter_group_orbits/ash/types.h
@@ -24,13 +24,13 @@
 #include <iostream>
 #include <initializer_list>
 #include <math.h>
-#include "stl_wrappers.h"
+//#include "stl_wrappers.h"
 
 class NotImplementedException : public std::exception {};
 class InvalidGroupException : public std::exception {};
 
 typedef long double NumberType;
-const static NumberType epsilon = .0000001;
+const static NumberType epsilon = 1.E-14;
 
 class ImpreciseVector : public std::vector<NumberType>
 {
@@ -80,8 +80,8 @@ void output_vector(const VectorType& item)
       std::cout << "]\n";
    }
 
-template<typename ElementType>
-void output_set(const std::set<ElementType>& item)
+template<typename Element_type>
+void output_set(const std::set<Element_type>& item)
 {
       std::cout << '[';
       bool first = true;

--- a/coxeter_group_orbits/ash/types.h
+++ b/coxeter_group_orbits/ash/types.h
@@ -30,7 +30,7 @@ class NotImplementedException : public std::exception {};
 class InvalidGroupException : public std::exception {};
 
 typedef long double NumberType;
-const static NumberType epsilon = .5;
+const static NumberType epsilon = .0000001;
 
 class ImpreciseVector : public std::vector<NumberType>
 {
@@ -66,7 +66,10 @@ public:
 
 };
 
-void output_vector(const ImpreciseVector& item)
+typedef std::vector<NumberType> VectorType;//ImpreciseVector VectorType; 
+typedef std::set<VectorType> Orbit;
+
+void output_vector(const VectorType& item)
    {
       std::cout << "[1,";
       bool first = true;
@@ -74,7 +77,7 @@ void output_vector(const ImpreciseVector& item)
          std::cout << (!first ? "," : "") << element;
          first = false;
       }
-      std::cout << ']';
+      std::cout << "]\n";
    }
 
 template<typename ElementType>
@@ -89,12 +92,6 @@ void output_set(const std::set<ElementType>& item)
       }
       std::cout << ']';
 }
-
-
-
-typedef ImpreciseVector VectorType; //std::vector<NumberType, ImpreciseComp> VectorType;//
-typedef std::set<VectorType> Orbit;
-
 class GeneratorList : public std::vector<VectorType> {
 public:
    GeneratorList(int r, int c) : std::vector<VectorType>(r)


### PR DESCRIPTION
As we discussed on monday, we implemented the normal lexicographical tree with more careful inserting. This way we do not need a transitive operation, because we are checking for impreciseEquality with every element whichs first component is in an open epsilon-ball. Of cause this is very expensive, especially for higher dimensions, where we have many mirrors leaving the first component unchanged.
